### PR TITLE
fix: import error for pycocotools._mask

### DIFF
--- a/lib/dataset/pycocotools/mask.py
+++ b/lib/dataset/pycocotools/mask.py
@@ -1,6 +1,6 @@
 __author__ = 'tsungyi'
 
-import _mask as _mask
+import pycocotools._mask as _mask
 
 # Interface for manipulating masks stored in RLE format.
 #


### PR DESCRIPTION
fix import error when inport _mask in Desktop/Relation-Networks-for-Object-Detection/lib/dataset/pycocotools/mask.py